### PR TITLE
Add double-quotes to path names in cmd files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,8 @@ publish/
 !**/packages/build/
 # Uncomment if necessary however generally it will be regenerated when needed
 #!**/packages/repositories.config
+# Ignore nuget.exe
+**/.nuget/*
 
 # Windows Azure Build Output
 csx/

--- a/build.cmd
+++ b/build.cmd
@@ -5,15 +5,15 @@ SETLOCAL
 SET NUGET_VERSION=latest
 SET CACHED_NUGET=%LocalAppData%\NuGet\nuget.%NUGET_VERSION%.exe
 
-IF EXIST %CACHED_NUGET% goto copynuget
+IF EXIST "%CACHED_NUGET%" goto copynuget
 echo Downloading latest version of NuGet.exe...
-IF NOT EXIST %LocalAppData%\NuGet md %LocalAppData%\NuGet
+IF NOT EXIST "%LocalAppData%\NuGet" md "%LocalAppData%\NuGet"
 @powershell -NoProfile -ExecutionPolicy unrestricted -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/%NUGET_VERSION%/nuget.exe' -OutFile '%CACHED_NUGET%'"
 
 :copynuget
 IF EXIST .nuget\nuget.exe goto restore
 md .nuget
-copy %CACHED_NUGET% .nuget\nuget.exe > nul
+copy "%CACHED_NUGET%" ".nuget\nuget.exe" > nul
 
 :restore
 IF EXIST packages\Sake goto run

--- a/dnvm.cmd
+++ b/dnvm.cmd
@@ -4,7 +4,7 @@ for /f "delims=" %%i in ('PowerShell -NoProfile -NoLogo -ExecutionPolicy unrestr
 
 PowerShell -NoProfile -NoLogo -ExecutionPolicy bypass -Command "[System.Threading.Thread]::CurrentThread.CurrentCulture = ''; [System.Threading.Thread]::CurrentThread.CurrentUICulture = '';$CmdPathFile='%DNVM_CMD_PATH_FILE%';& '%~dp0dnvm.ps1' %*"
 
-IF EXIST %DNVM_CMD_PATH_FILE% (
-  CALL %DNVM_CMD_PATH_FILE%
-  DEL %DNVM_CMD_PATH_FILE%
+IF EXIST "%DNVM_CMD_PATH_FILE%" (
+  CALL "%DNVM_CMD_PATH_FILE%"
+  DEL "%DNVM_CMD_PATH_FILE%"
 )

--- a/makefile.shade
+++ b/makefile.shade
@@ -37,7 +37,7 @@ functions
 												"Server=localhost;Database=ContosoUniversity2016.Tests;Trusted_Connection=True;MultipleActiveResultSets=true";
 	}
 
-#defalult .restore .rdb .rat description="Comprehensive Building|Ensures the environment is initialized:  installs dnx if needed and rebuilds the databases."
+#default .restore .rdb .rat description="Comprehensive Building|Ensures the environment is initialized:  installs dnx if needed and rebuilds the databases."
 	@{
 		ReportTime();
 


### PR DESCRIPTION
When we call IF EXISTS and other commands in a batch file, and the given path has spaces then this command will silently fail. We enclose the passed path with double quotes so that the condition executes successfully. This commit will prevent build.cmd failing when %LocalAppData% path contains spaces (as mine did).
